### PR TITLE
Assorted fixes for making Algorithm::Diff work again on current rakudo

### DIFF
--- a/lib/Algorithm/Diff.pm
+++ b/lib/Algorithm/Diff.pm
@@ -53,7 +53,7 @@ sub _withPositionsOfInInterval( @aCollection, $start, $end, &keyGen )
 # This is where the bulk (75%) of the time is spent in this module, so
 # try to make it fast!
 
-our sub _replaceNextLargerWith( @array is rw, $aValue, $high is copy )
+our sub _replaceNextLargerWith( @array, $aValue, $high is copy )
 {
     $high ||= +@array-1;
 

--- a/lib/Algorithm/Diff.pm
+++ b/lib/Algorithm/Diff.pm
@@ -420,7 +420,7 @@ sub LCS_length( @a, @b, &keyGen = &default_keyGen ) is export
 sub LCSidx( @a, @b, &keyGen = &default_keyGen ) is export
 {
      my @match = _longestCommonSubsequence( @a, @b, 0, &keyGen );
-     my $amatch_indices = (^@match).grep: { @match[$^a].defined };
+     my $amatch_indices = (^@match).grep({ @match[$^a].defined }).list;
      my $bmatch_indices = @match[@$amatch_indices];
      # return list references, @arrays will flatten
      return ($amatch_indices, $bmatch_indices);

--- a/t/base.t
+++ b/t/base.t
@@ -48,9 +48,9 @@ is(  @result.grep( *.defined ).elems(),
 # result has b[] line#s keyed by a[] line#
 #say "result = " ~ @result;
 
-my @aresult = map { @result[$_].defined ?? @a[$_] !! () } , 0..^@result;
+my @aresult = map { @result[$_].defined ?? @a[$_] !! slip() } , 0..^@result;
 
-my @bresult = map { @result[$_].defined ?? @b[@result[$_]]  !! () } , 0..^@result;
+my @bresult = map { @result[$_].defined ?? @b[@result[$_]]  !! slip() } , 0..^@result;
 
 is( ~@aresult, $correctResult,
   "_longestCommonSubsequence @a results match expected results" );


### PR DESCRIPTION
* remove now-illegal "is rw" on array parameter
* fix fallout from the Great List Refactoring