### PR TITLE
Allow specific export of traverse_sequences

### DIFF
--- a/lib/Algorithm/Diff.pm
+++ b/lib/Algorithm/Diff.pm
@@ -232,7 +232,7 @@ sub traverse_sequences(
     :DISCARD_B( &discard_b ),
     :A_FINISHED( &finished_a ) is copy,
     :B_FINISHED( &finished_b ) is copy
-) is export
+) is export(:traverse_sequences :DEFAULT)
 {
 
     my @matchVector = _longestCommonSubsequence( @a, @b, 0, &keyGen );


### PR DESCRIPTION
Diff isn't always wanted.

I've been working on a port of Text::Diff which wants to create a diff subroutine itself. Raku gives the exporting module full control, so I'd like to make most of Algorithm::Diff exports optional.